### PR TITLE
Fixing issues with swap command and character input 

### DIFF
--- a/gaot_plus_plus.py
+++ b/gaot_plus_plus.py
@@ -119,8 +119,8 @@ class Gaot(object):
 	def _swap(self):
 		x,y = self.stack.pop(), self.stack.pop()
 
-		self.stack.push(y)
 		self.stack.push(x)
+		self.stack.push(y)
 
 	def _reverse_stack(self):
 		self.stack = Stack(self.stack.get()[::-1])

--- a/gaot_plus_plus.py
+++ b/gaot_plus_plus.py
@@ -110,8 +110,17 @@ class Gaot(object):
 		self.stack.push(float(raw_input()))
 
 	def _getchar(self):
-		_ = ord(getch())
-		self.stack.append(_*(_!=4))
+		# check if stdin is connected to a terminal
+		if sys.stdin.isatty():
+			_ = ord(getch())
+			self.stack.append(_*(_!=4))
+		else:
+			# getch() doesn't work with non-terminals
+			ch = sys.stdin.read(1)
+			if ch == '':
+				self.stack.append(0)
+			else:
+				self.stack.append(ord(ch))
 
 	def _dupe(self):
 		self.stack.push(self.stack.peek())

--- a/gaot_plus_plus.py
+++ b/gaot_plus_plus.py
@@ -39,7 +39,7 @@ class Gaot(object):
 
 	def run(self, program):
 		self.instructions = program.split()
-		while self.ipointer < len(self.instructions):
+		while self.ipointer < len(self.instructions) and self.ipointer >= 0:
 			c = self.instructions[self.ipointer]
 
 			if self.BAA.search(c): # is a "baa" command

--- a/gaot_plus_plus.py
+++ b/gaot_plus_plus.py
@@ -135,9 +135,10 @@ class Gaot(object):
 		self.stack = Stack(self.stack.get()[::-1])
 
 	def _rotate_stack(self):
-		x = self.stack[0]
-		self.stack = Stack(self.stack[1:])
-		self.stack.push(x)
+		if len(self.stack) > 1:
+			x = self.stack[0]
+			self.stack = Stack(self.stack[1:])
+			self.stack.push(x)
 
 def main():
     gaot = Gaot()

--- a/gaot_plus_plus.py
+++ b/gaot_plus_plus.py
@@ -135,8 +135,10 @@ class Gaot(object):
 		self.stack = Stack(self.stack.get()[::-1])
 
 	def _rotate_stack(self):
-		_ = self.stack.get()
-		self.stack = Stack(x[1:]+x[0])
+		x = self.stack[0]
+		self.stack = Stack(self.stack[1:])
+		self.stack.push(x)
+
 def main():
     gaot = Gaot()
     gaot.run(gaot.get_code())

--- a/getch.py
+++ b/getch.py
@@ -2,7 +2,6 @@
 # coding=utf-8
 
 # Last modified: <2012-05-10 18:04:45 Thursday by richard>
-# 2021-11-26 by Anthony Kozar: Only use termios if stdin is a tty.
 
 # @version 0.1
 # @author : Richard Wong
@@ -31,19 +30,13 @@ class _GetchUnix:
 
     def __call__(self):
         import sys, tty, termios
-        if sys.stdin.isatty():
-            fd = sys.stdin.fileno()
-            old_settings = termios.tcgetattr(fd)
-            try:
-                tty.setraw(sys.stdin.fileno())
-                ch = sys.stdin.read(1)
-            finally:
-                termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
-                return ch
-        else:
+        fd = sys.stdin.fileno()
+        old_settings = termios.tcgetattr(fd)
+        try:
+            tty.setraw(sys.stdin.fileno())
             ch = sys.stdin.read(1)
-            if ch == '':
-                ch = '\x04' # EOF
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
             return ch
 
 


### PR DESCRIPTION
I found multiple problems with this implementation of Gaot++ while using it from TryItOnline.  The first is that the swap command doesn't swap the top two entries on the stack.  It pops them off and then pushes them back on in the same order they were in before.  The following program demonstrates this bug.

```
baa baaa
bleeeeeeeeeeeeeet
bleeeeeeeeet bleeeeeeeeet
```

The program pushes 1 and then 2 onto the stack, swaps them, and then outputs the top two entries of the stack as numbers.  It should produce the output "12" but instead gives "21".

The second issue is that character input throws an exception whenever standard input is not connected to a terminal.  This affects Gaot++ programs running on TryItOnline or running from a commandline with input redirection.  This simple program should read a single character from stdin and output it as a character:

`bleeeeeeeeeeeet bleeeeeeeeeet`

On TryItOnline, it produces this exception:

```
Traceback (most recent call last):
  File "/opt/gaotpp/gaot_plus_plus.py", line 136, in <module>
    main()
  File "/opt/gaotpp/gaot_plus_plus.py", line 133, in main
    gaot.run(gaot.get_code())
  File "/opt/gaotpp/gaot_plus_plus.py", line 50, in run
    self.commands[n-2]()
  File "/opt/gaotpp/gaot_plus_plus.py", line 113, in _getchar
    _ = ord(getch())
  File "/opt/gaotpp/getch.py", line 24, in __call__
    return self.impl()
  File "/opt/gaotpp/getch.py", line 34, in __call__
    old_settings = termios.tcgetattr(fd)
termios.error: (25, 'Inappropriate ioctl for device')
```

This pull request resolves both of these issues.  With these patches, the "cat" program example from esolangs.org can be used to copy the input to the output as expected. (Unless the input contains an embedded NULL character.  See the notes on the last commit).

**Dec. 8:** I've added 3 more commits to this pull request that fix additional bugs.  The first commit halts a Gaot++ program when the instruction pointer becomes negative which could happen if the direction of the instruction pointer was reversed and then went past the beginning of the program.  Since the interpreter halts a program that reaches the end of its code, it seemed to make sense to halt when in reverse too.

The next two commits fix problems with the rotate command.  (Try "baa baaa bleeeeeeeeeeeeeeeet" on TryItOnline).  The code previously referenced an undefined variable which produced the exception below and it tried to concatenate a list and an integer which is not allowed.  I also made sure that rotate does nothing when the stack is empty.

```
Traceback (most recent call last):
  File "/opt/gaotpp/gaot_plus_plus.py", line 136, in <module>
    main()
  File "/opt/gaotpp/gaot_plus_plus.py", line 133, in main
    gaot.run(gaot.get_code())
  File "/opt/gaotpp/gaot_plus_plus.py", line 50, in run
    self.commands[n-2]()
  File "/opt/gaotpp/gaot_plus_plus.py", line 130, in _rotate_stack
    self.stack = Stack(x[1:]+x[0])
NameError: global name 'x' is not defined
```

If you have any questions, please let me know.  Thanks!

Anthony Kozar
